### PR TITLE
fixed bug on menu click listener

### DIFF
--- a/app/src/main/java/com/team41/boromi/utility/CustomClickListener.java
+++ b/app/src/main/java/com/team41/boromi/utility/CustomClickListener.java
@@ -126,9 +126,11 @@ public class CustomClickListener implements View.OnClickListener,
           public void onFailure(Exception e) {
           }
         });
+        return true;
       case R.id.exchange_book:
         genericListFragment.verifyBarcode(book);
 //          genericListFragment.bookExchangeRequest(book);
+        return true;
 
     }
     return false;


### PR DESCRIPTION
Whenever it clicks delete button, a scanner opens up as well. 
There was a problem in the switch case.