### PR TITLE
Text overflow fix and case sensitiveness on username

### DIFF
--- a/app/src/main/java/com/team41/boromi/auth/SignupFragment.java
+++ b/app/src/main/java/com/team41/boromi/auth/SignupFragment.java
@@ -131,7 +131,7 @@ public class SignupFragment extends Fragment {
         String username = userNameInput.getText().toString();
         String password = passwordInput.getText().toString();
         spinner.setVisibility(View.VISIBLE);
-        activity.getAuthController().makeSignUpRequest(username, email, password,
+        activity.getAuthController().makeSignUpRequest(username.toLowerCase(), email, password,
             new AuthCallback() {
               @Override
               public void onSuccess(AuthResult authResult) {

--- a/app/src/main/java/com/team41/boromi/book/EditUserFragment.java
+++ b/app/src/main/java/com/team41/boromi/book/EditUserFragment.java
@@ -76,7 +76,7 @@ public class EditUserFragment extends DialogFragment {
     @Override
     public void onClick(View v) {
       spinner.setVisibility(View.VISIBLE);
-      String username = editTextUsername.getText().toString();
+      String username = editTextUsername.getText().toString().toLowerCase();
       String email = editTextEmail.getText().toString();
       db = FirebaseFirestore.getInstance();
       UserDB userDB = new UserDB(db);
@@ -244,7 +244,7 @@ public class EditUserFragment extends DialogFragment {
     super.onDestroy();
     if (successfulWrite) {
       user = ((BookActivity) getActivity()).getUser();
-      String username = editTextUsername.getText().toString();
+      String username = editTextUsername.getText().toString().toLowerCase();
       String email = editTextEmail.getText().toString();
       user.setEmail(email);
       user.setUsername(username);

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -40,6 +40,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="username"
+            android:singleLine="true"
+            android:ellipsize="end"
             android:textAppearance="@style/TextAppearance.AppCompat.Headline" />
 
         <TextView


### PR DESCRIPTION
text overflow has ellipses now when its long for user profile
case sensitive uniqueness is kind of a problem. Firestore doesnt support case insensitive queries (on the website they recommend to use algolia api for elastic search). So, with the time crunch I changed the route. Whenever user signup or change username with captial letters, boromi will forcefully change it to all lower case and save it in db (will also display in lower case). 